### PR TITLE
Fix comment in sync tasks command

### DIFF
--- a/src/cli/syncTasksCommand.js
+++ b/src/cli/syncTasksCommand.js
@@ -238,7 +238,7 @@ module.exports = {
             }
 
             await upsertTaskToDb(task, argv.listId, trx); // Zapisz/aktualizuj zadanie
-            await syncTaskAssignees(task.id, task.assignees || [], trx); // Zsynchronizuj przypisanych
+            await syncTaskAssignees(task.id, task.assignees || [], trx); // Zsynchronizuj przypisanych użytkowników
 
             if (existingTask) {
               // Po upsercie: zmiana logiki dla updatedTasksCount


### PR DESCRIPTION
## Summary
- update the comment after `syncTaskAssignees` to use a full Polish sentence

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b5cb8a61c8332b2e61a0f3a84b1f3